### PR TITLE
Fix macOS, tvOS, watchOS platforms, and docs CI

### DIFF
--- a/Sources/Clocks/ImmediateClock.swift
+++ b/Sources/Clocks/ImmediateClock.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   import Foundation
 
   /// A clock that does not suspend when sleeping.

--- a/Sources/Clocks/Internal/_AnyClock.swift
+++ b/Sources/Clocks/Internal/_AnyClock.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   /// Internal use only. Not meant to be used outside the library.
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public struct _AnyClock<Duration: DurationProtocol & Hashable>: Clock {

--- a/Sources/Clocks/Internal/_AsyncTimerSequence.swift
+++ b/Sources/Clocks/Internal/_AsyncTimerSequence.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   //===----------------------------------------------------------------------===//
   //
   // This source file is part of the Swift Async Algorithms open source project

--- a/Sources/Clocks/Shims.swift
+++ b/Sources/Clocks/Shims.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   extension Clock {
     /// Suspends for the given duration.

--- a/Sources/Clocks/SwiftUI.swift
+++ b/Sources/Clocks/SwiftUI.swift
@@ -1,4 +1,4 @@
-#if canImport(SwiftUI) && (canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7)))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS)) && canImport(SwiftUI)
   import SwiftUI
 
   @available(macOS 13, iOS 16, watchOS 9, tvOS 16, *)

--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   import Foundation
   import XCTestDynamicOverlay
 

--- a/Sources/Clocks/Timer.swift
+++ b/Sources/Clocks/Timer.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   extension Clock where Duration: Hashable {
     /// Creates an async sequence that emits the clock's `now` value on an interval.

--- a/Sources/Clocks/UnimplementedClock.swift
+++ b/Sources/Clocks/UnimplementedClock.swift
@@ -1,4 +1,4 @@
-#if canImport(RoomPlan) || (!canImport(Darwin) && swift(>=5.7))
+#if swift(>=5.7) && (canImport(RegexBuilder) || !os(macOS))
   import Foundation
   import XCTestDynamicOverlay
 


### PR DESCRIPTION
Our static conditional wasn't quite right. It was overly exclusive towards iOS and macCatalyst platforms. Instead let's use the `RegexBuilder` module.