### PR TITLE
Add comment around platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 
 let package = Package(
   name: "swift-clocks",
-  // NB: Support earlier platforms so that depending libraries and applications can conditionally use the
-  //     library via availability checks against iOS 16+, etc.
+  // NB: While the `Clock` protocol is iOS 16+, etc., the package should support earlier platforms so that
+  //     dependending libraries and applications can conditionally use the library vai availability checks.
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "swift-clocks",
   // NB: While the `Clock` protocol is iOS 16+, etc., the package should support earlier platforms so that
-  //     dependending libraries and applications can conditionally use the library vai availability checks.
+  //     depending libraries and applications can conditionally use the library vai availability checks.
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,8 @@ import PackageDescription
 
 let package = Package(
   name: "swift-clocks",
+  // NB: Support earlier platforms so that depending libraries and applications can conditionally use the
+  //     library via availability checks against iOS 16+, etc.
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),


### PR DESCRIPTION
Clocks can be depended on in iOS applications and frameworks starting with iOS 13+, but the `Clock` protocol is only available in iOS 16+. Let's add a comment to clarify why (prompted by discussion: #14).