### PR TITLE
Add mega yield environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run tests
-        run: swift -c ${{ matrix.config }} test
+        run: swift test -c ${{ matrix.config }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,28 +15,25 @@ concurrency:
 
 jobs:
   library:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
-        xcode: ['14.0.1']
         config: ['debug', 'release']
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Select Xcode 14.3
+        run: sudo xcode-select -s /Applications/Xcode_14.3.app
       - name: Run ${{ matrix.config }} tests
         run: CONFIG=${{ matrix.config }} make test-all
+      - name: Build for library evolution
+        run: CONFIG=${{ matrix.config }} make build-for-library-evolution
 
   ubuntu-tests:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-
-    runs-on: ${{ matrix.os }}
-
+        config: ['debug', 'release']
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: swift build
+      - uses: actions/checkout@v3
       - name: Run tests
-        run: swift test
+        run: swift -c ${{ matrix.config }} test

--- a/Sources/Clocks/Internal/Yield.swift
+++ b/Sources/Clocks/Internal/Yield.swift
@@ -5,8 +5,10 @@ extension Task where Success == Failure, Failure == Never {
   //     we're not sure if there is an alternative. See this forum post for more information:
   //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
   static func megaYield(
-    count: Int = ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init)
-      ?? 20
+    count: Int = max(
+      ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init) ?? 20,
+      20
+    )
   ) async {
     for _ in 1...count {
       await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value

--- a/Sources/Clocks/Internal/Yield.swift
+++ b/Sources/Clocks/Internal/Yield.swift
@@ -1,8 +1,13 @@
+import Foundation
+
 extension Task where Success == Failure, Failure == Never {
   // NB: We would love if this was not necessary, but due to a lack of async testing tools in Swift
   //     we're not sure if there is an alternative. See this forum post for more information:
   //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
-  static func megaYield(count: Int = 10) async {
+  static func megaYield(
+    count: Int = ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init)
+      ?? 20
+  ) async {
     for _ in 1...count {
       await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
     }

--- a/Sources/Clocks/Internal/Yield.swift
+++ b/Sources/Clocks/Internal/Yield.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 extension Task where Success == Failure, Failure == Never {
-  // NB: We would love if this was not necessary, but due to a lack of async testing tools in Swift
-  //     we're not sure if there is an alternative. See this forum post for more information:
+  // NB: We would love if this was not necessary. See this forum post for more information:
   //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
   static func megaYield(count: Int = defaultMegaYieldCount) async {
     for _ in 0..<count {

--- a/Sources/Clocks/Internal/Yield.swift
+++ b/Sources/Clocks/Internal/Yield.swift
@@ -5,14 +5,14 @@ extension Task where Success == Failure, Failure == Never {
   //     we're not sure if there is an alternative. See this forum post for more information:
   //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
   static func megaYield(count: Int = defaultMegaYieldCount) async {
-    for _ in 1...count {
+    for _ in 0..<count {
       await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
     }
   }
 }
 
 let defaultMegaYieldCount = max(
-  1,
+  0,
   min(
     ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init) ?? 20,
     10_000

--- a/Sources/Clocks/Internal/Yield.swift
+++ b/Sources/Clocks/Internal/Yield.swift
@@ -4,14 +4,17 @@ extension Task where Success == Failure, Failure == Never {
   // NB: We would love if this was not necessary, but due to a lack of async testing tools in Swift
   //     we're not sure if there is an alternative. See this forum post for more information:
   //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
-  static func megaYield(
-    count: Int = max(
-      ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init) ?? 20,
-      20
-    )
-  ) async {
+  static func megaYield(count: Int = defaultMegaYieldCount) async {
     for _ in 1...count {
       await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
     }
   }
 }
+
+let defaultMegaYieldCount = max(
+  1,
+  min(
+    ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init) ?? 20,
+    10_000
+  )
+)


### PR DESCRIPTION
An idea suggested [here](https://github.com/pointfreeco/combine-schedulers/discussions/79). Because we reuse `Task.megaYield` in Clocks, Combine Schedulers, and TCA, we can use an environment variable to unify them.