### PR TITLE
Fix regression: test clock should hang till it is explicitly advanced

### DIFF
--- a/Clocks.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clocks.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "swift-async-algorithms",
+      "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "branch" : "cf70e78",
-        "revision" : "cf70e78632e990cd041fef21044e54fa5fdd1c56"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -32,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16e6409ee82e1b81390bdffbf217b9c08ab32784",
-        "version" : "0.5.0"
+        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -105,7 +105,7 @@
       let id = UUID()
       do {
         let stream: AsyncThrowingStream<Never, Error>? = self.lock.sync {
-          guard deadline > self.now
+          guard deadline >= self.now
           else {
             return nil
           }

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -213,4 +213,18 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
 
     XCTAssertEqual(values, [1, 2])
   }
+
+  func testSleepUntilExactlyNow() async throws {
+    let before = Date()
+    Task {
+      try await Task.sleep(for: .seconds(1))
+      await clock.advance()
+    }
+    try await clock.sleep(until: clock.now)
+    XCTAssertEqual(
+      before.advanced(by: 1).timeIntervalSince1970,
+      Date().timeIntervalSince1970,
+      accuracy: 0.2
+    )
+  }
 }

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -25,13 +25,6 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     XCTAssertEqual(checkIsFinished, true)
   }
 
-  func testSleepUntilExactlyNow() async throws {
-    let duration: Duration = .seconds(1)
-    let deadline = clock.now.advanced(by: duration)
-    await clock.advance(by: duration)
-    try await clock.sleep(until: deadline)
-  }
-
   func testAdvanceWithReentrantUnitsOfWork() async throws {
     let task = Task {
       var count = 0


### PR DESCRIPTION
We merged #22 a bit too hastily, but it introduced behavior that we didn't actually want. Let's revert this behavior and get a test in place so we don't deviate in the future.