### PR TITLE
Fix Testclock.advance(to:) flakiness

### DIFF
--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -45,6 +45,23 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     let ticks = try await task.value
     XCTAssertEqual(ticks, 5)
   }
+  
+  func testAdvanceWithThousandUnitsOfWork() async throws {
+    let timer = clock.timer(interval: .seconds(1))
+      .prefix(1000)
+    
+    let task = Task {
+      var ticks = 0
+      for await _ in timer {
+        ticks += 1
+      }
+      return ticks
+    }
+    
+    await self.clock.advance(by: .seconds(1000))
+    let ticks = await task.value
+    XCTAssertEqual(ticks, 1000)
+  }
 
   func testRun() async {
     let isFinished = ActorIsolated(false)


### PR DESCRIPTION
hi. now i am using swift-clocks in my project

### problem: 
After i attached the test to the CI (xcodecloud) in my project, I found flakiness of TestClock

<img width="1118" alt="Screenshot 2024-01-01 at 11 47 31 AM" src="https://github.com/pointfreeco/swift-clocks/assets/66512239/95597f64-9efe-41a4-b5c2-8dc45bf9e2a2">

### solution:
and after add withMainSerialExecutor on advance(to:), it's fixed
(I have run this test up to a 100,000 times.)

Thanks.