### PR TITLE
Fix AnyClock, ImmediateClock, TestClock `offset` from `var` to `let` 

### DIFF
--- a/Sources/Clocks/AnyClock.swift
+++ b/Sources/Clocks/AnyClock.swift
@@ -35,7 +35,7 @@
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public struct AnyClock<Duration: DurationProtocol & Hashable>: Clock {
     public struct Instant: InstantProtocol {
-      fileprivate var offset: Duration
+      fileprivate let offset: Duration
 
       public func advanced(by duration: Duration) -> Self {
         .init(offset: self.offset + duration)

--- a/Sources/Clocks/ImmediateClock.swift
+++ b/Sources/Clocks/ImmediateClock.swift
@@ -114,7 +114,8 @@
     Duration: Hashable
   {
     public struct Instant: InstantProtocol {
-      public var offset: Duration
+      public let offset: Duration
+    
       public init(offset: Duration = .zero) {
         self.offset = offset
       }

--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -66,7 +66,7 @@
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public final class TestClock<Duration: DurationProtocol & Hashable>: Clock, @unchecked Sendable {
     public struct Instant: InstantProtocol {
-      public var offset: Duration
+      public let offset: Duration
 
       public init(offset: Duration = .zero) {
         self.offset = offset


### PR DESCRIPTION
There is no need for 'offset' to be a var.