### PR TITLE
Update the default value of ImmediateClock.

### DIFF
--- a/Sources/Clocks/ImmediateClock.swift
+++ b/Sources/Clocks/ImmediateClock.swift
@@ -132,8 +132,8 @@
       }
     }
 
-    public var now = Instant()
-    public var minimumResolution = Instant.Duration.zero
+    public var now: Instant
+    public var minimumResolution: Duration = .zero
     private let lock = NSLock()
 
     public init(now: Instant = .init()) {


### PR DESCRIPTION
To improve consistency with other clocks and readability of the code, Update the default values of the variables in ImmediateClock.

e.g: TestClock initialization

```swift
    public var minimumResolution: Duration = .zero
    public private(set) var now: Instant

    private let lock = NSRecursiveLock()
    private var suspensions:
      [(
        id: UUID,
        deadline: Instant,
        continuation: AsyncThrowingStream<Never, Error>.Continuation
      )] = []

    public init(now: Instant = .init()) {
      self.now = now
    }
   ```