### PR TITLE
Fix access control

### DIFF
--- a/Sources/Clocks/AnyClock.swift
+++ b/Sources/Clocks/AnyClock.swift
@@ -61,7 +61,7 @@
       self._sleep = { try await clock.sleep(until: start.advanced(by: $0.offset), tolerance: $1) }
     }
 
-    public var minimumResolution: Instant.Duration {
+    public var minimumResolution: Duration {
       self._minimumResolution()
     }
 
@@ -69,7 +69,7 @@
       self._now()
     }
 
-    public func sleep(until deadline: Instant, tolerance: Instant.Duration? = nil) async throws {
+    public func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
       try await self._sleep(deadline, tolerance)
     }
   }

--- a/Sources/Clocks/ImmediateClock.swift
+++ b/Sources/Clocks/ImmediateClock.swift
@@ -114,8 +114,8 @@
     Duration: Hashable
   {
     public struct Instant: InstantProtocol {
-      public let offset: Duration
-    
+      fileprivate let offset: Duration
+
       public init(offset: Duration = .zero) {
         self.offset = offset
       }
@@ -133,15 +133,15 @@
       }
     }
 
-    public var now: Instant
-    public var minimumResolution: Duration = .zero
+    public private(set) var now: Instant
+    public private(set) var minimumResolution: Duration = .zero
     private let lock = NSLock()
 
     public init(now: Instant = .init()) {
       self.now = now
     }
 
-    public func sleep(until deadline: Instant, tolerance: Instant.Duration?) async throws {
+    public func sleep(until deadline: Instant, tolerance: Duration?) async throws {
       try Task.checkCancellation()
       self.lock.sync { self.now = deadline }
       await Task.megaYield()

--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -66,7 +66,7 @@
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   public final class TestClock<Duration: DurationProtocol & Hashable>: Clock, @unchecked Sendable {
     public struct Instant: InstantProtocol {
-      public let offset: Duration
+      fileprivate let offset: Duration
 
       public init(offset: Duration = .zero) {
         self.offset = offset

--- a/Tests/ClocksTests/ImmediateClockTests.swift
+++ b/Tests/ClocksTests/ImmediateClockTests.swift
@@ -22,8 +22,9 @@ final class ImmediateClockTests: XCTestCase {
 
   func testNow() async throws {
     let clock = ImmediateClock()
+    let start = clock.now
     try await clock.sleep(for: .seconds(5))
-    XCTAssertEqual(clock.now.offset, .seconds(5))
+    XCTAssertEqual(start.advanced(by: .seconds(5)), clock.now)
   }
 
   func testCooperativeCancellation() async throws {

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -186,8 +186,9 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     let task = Task {
       try await self.clock.sleep(for: .seconds(5))
     }
+    let start = self.clock.now
     await self.clock.advance(by: .seconds(5))
-    XCTAssertEqual(self.clock.now.offset, .seconds(5))
+    XCTAssertEqual(start.advanced(by: .seconds(5)), self.clock.now)
     try await task.value
   }
 


### PR DESCRIPTION
A few APIs were `public` when they shouldn't be. They aren't primary APIs, and it is unlikely that folks rely on them. So though this is a breaking change, it shouldn't affect folks, and there is an alternative API they can rely on instead.