### PR TITLE
Swift Language Support: Drop <5.9, Add 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,29 @@ concurrency:
 
 jobs:
   library:
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         config: ['debug', 'release']
     steps:
-      - uses: actions/checkout@v3
-      - name: Select Xcode 14.3
-        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - uses: actions/checkout@v4
+      - name: Select Xcode 15.4
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Run ${{ matrix.config }} tests
         run: CONFIG=${{ matrix.config }} make test-all
       - name: Build for library evolution
         run: CONFIG=${{ matrix.config }} make build-for-library-evolution
 
-  ubuntu-tests:
+  linux:
     strategy:
       matrix:
         config: ['debug', 'release']
+        swift:
+          - '5.10'
+    name: Linux (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         run: swift test -c ${{ matrix.config }}

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -38,12 +38,6 @@ let package = Package(
         "Clocks"
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v6]
 )
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings!.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-}

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -56,7 +56,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     var checkIsFinished = await isFinished.value
     XCTAssertEqual(checkIsFinished, false)
 
-    await self.clock.run()
+    await self.clock.run(timeout: .seconds(5))
     checkIsFinished = await isFinished.value
     XCTAssertEqual(checkIsFinished, true)
   }
@@ -85,9 +85,9 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
         }
       }
       for await _ in stream {}
-      await self.clock.run(timeout: .seconds(1))
+      await self.clock.run(timeout: .seconds(5))
       await isRunning.setValue(false)
-      await self.clock.run(timeout: .seconds(1))
+      await self.clock.run(timeout: .seconds(5))
     }
   #endif
 
@@ -161,7 +161,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     }
 
     task.cancel()
-    await self.clock.run()
+    await self.clock.run(timeout: .seconds(5))
 
     let actualDidFinish = await didFinish.value
     XCTAssertEqual(actualDidFinish, false)

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -56,7 +56,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     var checkIsFinished = await isFinished.value
     XCTAssertEqual(checkIsFinished, false)
 
-    await self.clock.run(timeout: .seconds(5))
+    await self.clock.run(timeout: .seconds(30))
     checkIsFinished = await isFinished.value
     XCTAssertEqual(checkIsFinished, true)
   }
@@ -103,7 +103,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
       return ticks
     }
 
-    await self.clock.run(timeout: .seconds(5))
+    await self.clock.run(timeout: .seconds(30))
     let ticks = await task.value
     XCTAssertEqual(ticks, 10)
   }
@@ -124,7 +124,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
       return count
     }
 
-    await self.clock.run(timeout: .seconds(5))
+    await self.clock.run(timeout: .seconds(30))
     let ticks = try await task.value
     XCTAssertEqual(ticks, 5)
   }
@@ -218,14 +218,14 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
   func testSleepUntilExactlyNow() async throws {
     let before = Date()
     Task {
-      try await Task.sleep(for: .seconds(5))
+      try await Task.sleep(for: .seconds(30))
       await clock.advance()
     }
     try await clock.sleep(until: clock.now)
     XCTAssertEqual(
-      before.advanced(by: 5).timeIntervalSince1970,
+      before.advanced(by: 30).timeIntervalSince1970,
       Date().timeIntervalSince1970,
-      accuracy: 1
+      accuracy: 5
     )
   }
 }

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -103,7 +103,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
       return ticks
     }
 
-    await self.clock.run(timeout: .seconds(1))
+    await self.clock.run(timeout: .seconds(5))
     let ticks = await task.value
     XCTAssertEqual(ticks, 10)
   }
@@ -124,7 +124,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
       return count
     }
 
-    await self.clock.run()
+    await self.clock.run(timeout: .seconds(5))
     let ticks = try await task.value
     XCTAssertEqual(ticks, 5)
   }
@@ -209,7 +209,7 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
     }
 
     try await Task.sleep(nanoseconds: 1_000_000_000)
-    await self.clock.run()
+    await self.clock.run(timeout: .seconds(5))
     let values = try await task.value
 
     XCTAssertEqual(values, [1, 2])
@@ -218,14 +218,14 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
   func testSleepUntilExactlyNow() async throws {
     let before = Date()
     Task {
-      try await Task.sleep(for: .seconds(1))
+      try await Task.sleep(for: .seconds(5))
       await clock.advance()
     }
     try await clock.sleep(until: clock.now)
     XCTAssertEqual(
-      before.advanced(by: 1).timeIntervalSince1970,
+      before.advanced(by: 5).timeIntervalSince1970,
       Date().timeIntervalSince1970,
-      accuracy: 0.2
+      accuracy: 1
     )
   }
 }

--- a/Tests/ClocksTests/TestClocksTests.swift
+++ b/Tests/ClocksTests/TestClocksTests.swift
@@ -85,9 +85,9 @@ final class TestClockTests: XCTestCase, @unchecked Sendable {
         }
       }
       for await _ in stream {}
-      await self.clock.run(timeout: .seconds(5))
+      await self.clock.run(timeout: .seconds(1))
       await isRunning.setValue(false)
-      await self.clock.run(timeout: .seconds(5))
+      await self.clock.run(timeout: .seconds(1))
     }
   #endif
 

--- a/Tests/ClocksTests/UnimplementedClockTests.swift
+++ b/Tests/ClocksTests/UnimplementedClockTests.swift
@@ -4,7 +4,6 @@
 
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
   final class UnimplementedClockTests: XCTestCase {
-    @MainActor
     func testUnimplementedClock() async throws {
       XCTExpectFailure {
         [
@@ -18,7 +17,6 @@
       try await clock.sleep(for: .seconds(1))
     }
 
-    @MainActor
     func testUnimplementedClock_WithName() async throws {
       XCTExpectFailure {
         [
@@ -32,7 +30,6 @@
       try await clock.sleep(for: .seconds(1))
     }
 
-    @MainActor
     func testNow() async throws {
       XCTExpectFailure {
         [
@@ -46,18 +43,17 @@
       try await clock.sleep(for: .seconds(5))
     }
 
-    @MainActor
     func testCooperativeCancellation() async throws {
-      XCTExpectFailure {
-        [
-          "Unimplemented: Clock.sleep",
-          "Unimplemented: Clock.now",
-        ]
-        .contains($0.compactDescription)
-      }
-
       let clock = UnimplementedClock()
       let task = Task {
+        XCTExpectFailure {
+          [
+            "Unimplemented: Clock.sleep",
+            "Unimplemented: Clock.now",
+          ]
+          .contains($0.compactDescription)
+        }
+
         try? await Task.sleep(nanoseconds: 1_000_000_000 / 3)
         try await clock.sleep(for: .seconds(1))
       }


### PR DESCRIPTION
We can drop Swift <5.9 now that the App Store requires Xcode 15 for submissions, and we can add 6.0 language mode to keep our concurrency story in check.