### PR TITLE
Update Package@swift-6.0.swift

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -39,5 +39,5 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageVersions: [.v6]
+  swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
Fix another instance of

```
'swift-clocks': /__w/SwiftPackageIndex-Server/SwiftPackageIndex-Server/.build/checkouts/swift-clocks/Package@swift-6.0.swift:5:15: warning: 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is deprecated: replaced by 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)'
```