### PR TITLE
Update package versioning

### DIFF
--- a/Clocks.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Clocks.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "ed7ab9572c69a3dc124037a3b24680f7164dd032be3ba0cf3451ff4f654deccd",
   "pins" : [
     {
       "identity" : "swift-concurrency-extras",
@@ -28,14 +29,14 @@
       }
     },
     {
-      "identity" : "swift-issue-reporting",
+      "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -38,12 +38,6 @@ let package = Package(
         "Clocks"
       ]
     ),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings!.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -38,6 +38,12 @@ let package = Package(
         "Clocks"
       ]
     ),
-  ],
-  swiftLanguageModes: [.v6]
+  ]
 )
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings!.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+}


### PR DESCRIPTION
SPM recommends `Package.swift` point to the latest version, but we're doing the opposite.