### PR TITLE
Correct documentation comment in TestClock

### DIFF
--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -25,7 +25,7 @@
   ///   func startTimerButtonTapped() {
   ///     self.timerTask = Task {
   ///       while true {
-  ///         try await self.clock.sleep(for: .seconds(5))
+  ///         try await self.clock.sleep(for: .seconds(1))
   ///         self.count += 1
   ///       }
   ///     }


### PR DESCRIPTION
The example test code seems to expect the clock to sleep for .seconds(1) per tick.