### PR TITLE
Add `.test` clock constructor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "ed7ab9572c69a3dc124037a3b24680f7164dd032be3ba0cf3451ff4f654deccd",
   "pins" : [
     {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -14,14 +15,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
@@ -32,10 +33,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/Clocks/Documentation.docc/ImmediateClock.md
+++ b/Sources/Clocks/Documentation.docc/ImmediateClock.md
@@ -4,5 +4,6 @@
 
 ### Creating immediate clocks
 
+- ``_Concurrency/Clock/immediate``
 - ``init(now:)``
 - ``init()``

--- a/Sources/Clocks/Documentation.docc/TestClock.md
+++ b/Sources/Clocks/Documentation.docc/TestClock.md
@@ -4,6 +4,7 @@
 
 ### Creating test clocks
 
+- ``_Concurrency/Clock/test``
 - ``init(now:)``
 - ``init()``
 

--- a/Sources/Clocks/Documentation.docc/UnimplementedClock.md
+++ b/Sources/Clocks/Documentation.docc/UnimplementedClock.md
@@ -4,5 +4,6 @@
 
 ### Creating unimplemented clocks
 
+- ``_Concurrency/Clock/unimplemented(fileID:filePath:line:column:)``
 - ``init(name:now:)``
 - ``init(name:)``

--- a/Sources/Clocks/ImmediateClock.swift
+++ b/Sources/Clocks/ImmediateClock.swift
@@ -160,19 +160,6 @@
     /// A clock that does not suspend when sleeping.
     ///
     /// Constructs and returns an ``ImmediateClock``
-    ///
-    /// > Important: Due to [a bug in Swift](https://github.com/apple/swift/issues/61645), this static
-    /// > value cannot be used in an existential context:
-    /// >
-    /// > ```swift
-    /// > let clock: any Clock<Duration> = .immediate  // 🛑
-    /// > ```
-    /// >
-    /// > To work around this bug, construct an immediate clock directly:
-    /// >
-    /// > ```swift
-    /// > let clock: any Clock<Duration> = ImmediateClock()  // ✅
-    /// > ```
     public static var immediate: Self {
       ImmediateClock()
     }

--- a/Sources/Clocks/TestClock.swift
+++ b/Sources/Clocks/TestClock.swift
@@ -281,4 +281,14 @@
       self.init(now: .init())
     }
   }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  extension Clock where Self == TestClock<Swift.Duration> {
+    /// A clock whose time can be controlled in a deterministic manner.
+    ///  
+    /// Constructs and returns an ``TestClock``.
+    public static var test: Self {
+      TestClock()
+    }
+  }
 #endif

--- a/Sources/Clocks/UnimplementedClock.swift
+++ b/Sources/Clocks/UnimplementedClock.swift
@@ -169,19 +169,6 @@
     /// A clock that causes an XCTest failure when any of its endpoints are invoked.
     ///
     /// Constructs and returns an ``UnimplementedClock``
-    ///
-    /// > Important: Due to [a bug in Swift <6](https://github.com/apple/swift/issues/61645), this
-    /// > static value cannot be used in an existential context:
-    /// >
-    /// > ```swift
-    /// > let clock: any Clock<Duration> = .unimplemented()  // 🛑
-    /// > ```
-    /// >
-    /// > To work around this bug, construct an unimplemented clock directly:
-    /// >
-    /// > ```swift
-    /// > let clock: any Clock<Duration> = UnimplementedClock()  // ✅
-    /// > ```
     public static func unimplemented(
       fileID: StaticString = #fileID,
       filePath: StaticString = #filePath,


### PR DESCRIPTION
While not super useful on its own, when used in tandem with certain casting helpers, it can be a little nicer. For example, when writing tests using swift-dependencies:

```swift
@Suite(.dependency(\.continuousClock, .test))
struct MyTests {
  @Dependency(\.continuousClock, as: TestClock<Duration>.self) var clock

  // ...
}
```