### PR TITLE
Fix documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/pointfreeco/swift-clocks/discussions
     about: Library Q&A, ideas, and more
   - name: Documentation
-    url: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/
+    url: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks
     about: Read the documentation
   - name: Videos
     url: https://www.pointfree.co/collections/concurrency/clocks


### PR DESCRIPTION
Updates the issue template documentation contact link to Swift Package Index DocC.